### PR TITLE
Add Dockerfile to mirror Quay.io

### DIFF
--- a/Dockerfile.mirror
+++ b/Dockerfile.mirror
@@ -1,0 +1,1 @@
+FROM quay.io/jakirkham/centos_conda


### PR DESCRIPTION
As usual, building on Docker Hub is pretty slow. Not to mention the lack of a live updating log. Given Quay.io has this stuff right and we already got it to work, just add a Dockerfile to use as a mirror for Docker Hub.