### PR TITLE
Configure `conda` in system location

### DIFF
--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -43,10 +43,10 @@ do
     # Configure `conda` and add to the path
     export PATH="${INSTALL_CONDA_PATH}/bin:${OLD_PATH}"
     source activate root
-    conda config --set show_channel_urls True
+    conda config --system --set show_channel_urls True
 
     # Add conda-forge to our channels.
-    conda config --add channels conda-forge
+    conda config --system --add channels conda-forge
 
     # Provide an empty pinning file should it be needed.
     touch "${INSTALL_CONDA_PATH}/conda-meta/pinned"


### PR DESCRIPTION
Instead of configuring `conda` such that it creates a `.condarc` in `root`'s home directory, configure `conda` to use the system location config location instead. This adds `.condarc` to the top level of the `conda` install. Should avoid some issues with Singularity related to having content in `root`'s home directory.