### PR TITLE
Cleanup of `root`'s home directory

### DIFF
--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -83,6 +83,7 @@ do
 
     # Clean out all unneeded intermediates.
     conda clean -tipsy
+    rm -rf ~/.conda
 
     # Provide links in standard path.
     ln -s "${INSTALL_CONDA_PATH}/bin/python"  "/usr/local/bin/python${PYTHON_VERSION}"

--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -39,6 +39,7 @@ do
     openssl md5 "miniconda${PYTHON_VERSION}.sh" | grep "${MINICONDA_CHECKSUM}"
     bash "miniconda${PYTHON_VERSION}.sh" -b -p "${INSTALL_CONDA_PATH}"
     rm "miniconda${PYTHON_VERSION}.sh"
+    rm -rf ~/.pki
 
     # Configure `conda` and add to the path
     export PATH="${INSTALL_CONDA_PATH}/bin:${OLD_PATH}"


### PR DESCRIPTION
This removes the `.pki` and `.conda` directories created during the download of Miniconda and the install/update of `conda` packages. This should leave `root`'s home directory the same as it was in the `centos:6` image. Also should make it more friendly for conversion to a Singularity image.