### PR TITLE
Install `mesa-libGL` for `conda-forge`'s `qt`

### DIFF
--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -11,8 +11,8 @@ yum install -y -q curl
 # Install bzip2.
 yum install -y -q bzip2 tar
 
-# Install dependencies of conda's Qt4.
-yum install -y -q libSM libXext libXrender
+# Install dependencies of conda-forge's Qt.
+yum install -y -q libSM libXext libXrender mesa-libGL
 
 # Install basic fonts (needed by things like Graphviz).
 yum install -y -q urw-fonts


### PR DESCRIPTION
As `conda-forge`' copy of `qt` is linked to `libGL`, we need to provide it so that `matplotlib` can be imported using the `qt`-backed. Hence we install `mesa-libGL` via `yum`, which seems to solve this problem.