### PR TITLE
Set LANG to en_US.UTF-8

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ MAINTAINER John Kirkham <jakirkham@gmail.com>
 # Add a timestamp for the build. Also, bust the cache.
 ADD http://tycho.usno.navy.mil/timer.html /opt/docker/etc/timestamp
 
+ENV LANG en_US.UTF-8
+
 RUN echo "exclude=*.i386 *.i686" >> /etc/yum.conf && \
     yum update -y -q && \
     yum clean all -y -q


### PR DESCRIPTION
Python often expects `LANG` to be set to some encoding. Normally setting it to some form of UTF-8 works well. The `en_US.UTF-8` is preincluded in the CentOS 6 image; so, that's a reasonable choice to set the encoding to use and ensure UTF-8 is supported.