### PR TITLE
Make bash an interactive, login shell

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -il
 
 
 set -e


### PR DESCRIPTION
In the Docker entrypoint, call `bash` at the beginning with `-il` to make sure `bash` creates an interactive, login shell. The interactive option ensures that `bash` uses a TTY, runs startup, `*rc` files, has a prompt, and enables job control. Generally these are desirable features as we plan to use `bash` interactively. The login option makes sure that shell profiles and/or login scripts are run and sourced. All of these in general ensure the shell created when starting the container is as normal as possible.