### PR TITLE
Follow-up activation fixes for conda 4.4+

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,7 +4,6 @@
 set -e
 
 # Activate the default conda's base environment
-. /opt/conda/etc/profile.d/conda.sh
 conda activate base
 
 # Run whatever the user wants to

--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -95,5 +95,4 @@ do
 done
 
 # Set the conda3 environment as the default.
-# This should be removed in the future.
 ln -s /opt/conda3 /opt/conda

--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -96,3 +96,4 @@ done
 
 # Set the conda3 environment as the default.
 ln -s /opt/conda3 /opt/conda
+ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh


### PR DESCRIPTION
Follow-up to PR ( https://github.com/jakirkham/docker_centos_conda/pull/11 )

Adds some fixes for `conda` 4.4+ activation/deactivation. Namely runs `conda.sh` as part of `profile.d`'s setup scripts for interactive shells. This seems to fix activation/deactivation of `conda` environments when using the entrypoint giving `conda` the usually expected behavior.