### PR TITLE
Activate conda in the entrypoint

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -5,6 +5,7 @@ set -e
 
 # Activate the default conda's base environment
 set -a
+. /opt/conda/etc/profile.d/conda.sh
 conda activate base
 set +a
 

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -4,7 +4,9 @@
 set -e
 
 # Activate the default conda's base environment
+set -a
 conda activate base
+set +a
 
 # Run whatever the user wants to
 exec "$@"

--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -96,4 +96,3 @@ done
 
 # Set the conda3 environment as the default.
 ln -s /opt/conda3 /opt/conda
-ln -s /opt/conda/etc/profile.d/conda.sh /etc/profile.d/conda.sh


### PR DESCRIPTION
Follow-up to PR ( https://github.com/jakirkham/docker_centos_conda/pull/11 ) and PR ( https://github.com/jakirkham/docker_centos_conda/pull/12 ).

Runs the builtin `set -a` before calling `conda activate`, this ensures that all variables set are automatically `export`ed. Runs `set +a` afterwards to ensure no later commands affect environment variables that are exported. As a result when `conda activate` assigns environment variables, these are automatically exported ensuring the activated session persists to whatever is `exec`ed at the end.

Further the `conda.sh` profile script can also be run after `set -a` ensuring all functions and variables it defines are exported. This last part allows the `/etc/profile.d/` hack to be dropped. Avoiding a predisposition towards the Python 3 environment unnecessarily. Should make it easier as we switch between the two.

ref: http://man7.org/linux/man-pages/man1/set.1p.html
ref: http://pubs.opengroup.org/onlinepubs/9699919799.2016edition/utilities/V3_chap02.html#set