### PR TITLE
Use new time server to bust cache

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM centos:6
 MAINTAINER John Kirkham <jakirkham@gmail.com>
 
 # Add a timestamp for the build. Also, bust the cache.
-ADD http://tycho.usno.navy.mil/timer.html /opt/docker/etc/timestamp
+ADD https://now.httpbin.org/when/now /opt/docker/etc/timestamp
 
 ENV LANG en_US.UTF-8
 


### PR DESCRIPTION
Appears that USNO's time server redirects to `https`, but their certificates are invalid for some reason. Probably a consequence of their recent move to `https`. Would expect them to fix this in the future. For now, switch to a new time server to bust the cache. This provides the output in JSON with a few formats as opposed to a simple string, but is otherwise just text. Should work for our needs.