### PR TITLE
Ensure that `python` comes from `conda-forge` only

### DIFF
--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -64,10 +64,12 @@ do
 
     # Update conda and other basic dependencies.
     conda update -qy conda
-    conda update -qy --all
 
     # Update to latest Python minor version.
-    conda install -qy "python=${PYTHON_VERSION}"
+    # Ensure we use conda-forge's python no matter what.
+    conda install -qy "conda-forge::python=${PYTHON_VERSION}"
+
+    # Update everything else.
     conda update -qy --all
 
     # Install some other conda relevant packages.


### PR DESCRIPTION
Use `conda`'s new MatchSpec feature to pin `python` to the `conda-forge` channel. As some of the installation steps were causing `python` to get pulled from `defaults` instead (possibly due to its somewhat outdated pinned dependencies), this is needed to ensure that `python` only comes from `conda-forge`. Also this is a bit more effective at pinning `python` version in the environment thanks to MatchSpec. As the environment inherits this pinning, we can be sure that this constraint will be upheld for all later installation steps within this Docker image build or later images.