### PR TITLE
Keep only the conda-forge channel

### DIFF
--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -57,6 +57,7 @@ do
 
     # Add conda-forge to our channels.
     conda config --system --set show_channel_urls True
+    conda config --system --remove channels defaults
     conda config --system --add channels conda-forge
 
     # Provide an empty pinning file should it be needed.

--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -67,8 +67,7 @@ do
     conda update -qy conda
 
     # Update to latest Python minor version.
-    # Ensure we use conda-forge's python no matter what.
-    conda install -qy "conda-forge::python=${PYTHON_VERSION}"
+    conda install -qy "python=${PYTHON_VERSION}"
 
     # Update everything else.
     conda update -qy --all

--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -92,7 +92,7 @@ do
         # Mercurial is Python 2 only.
         conda install -qy mercurial
     fi
-    conda install -qy svn
+    conda install -qy defaults::svn
 
     # Clean out all unneeded intermediates.
     conda clean -tipsy


### PR DESCRIPTION
As there have been some issues with `defaults` packages replacing `conda-forge` packages for unknown reasons ( e.g. https://github.com/jakirkham/docker_centos_conda/pull/17 ), we have needed to occasionally pin the packages to the `conda-forge` channel. This is a bit painful to maintain and seems unnecessary given nearly all of our stack is in `conda-forge` and channel priority should already guarantee that preference is upheld.

To fix this, just remove the `defaults` channel and only add the `conda-forge` channel. Install anything that needs to come from `defaults` by pinning the packages to that channel (just `svn` FWICT). Should ensure that everything comes from `conda-forge` when possible and nothing gets unceremoniously replaced by at least requiring that we specify the package come from a different channel.