### PR TITLE
Pin Python 3.6 temporarily

### DIFF
--- a/miniconda/install_miniconda.sh
+++ b/miniconda/install_miniconda.sh
@@ -63,6 +63,10 @@ do
     # Provide an empty pinning file should it be needed.
     touch "${INSTALL_CONDA_PATH}/conda-meta/pinned"
 
+    # Pin Python major minor version to match installer.
+    PYTHON_VERSION="$(python -c 'import sys; print("%i.%i" % (sys.version_info[:2]))')"
+    echo "python ${PYTHON_VERSION}.*" >> "${INSTALL_CONDA_PATH}/conda-meta/pinned"
+
     # Update conda and other basic dependencies.
     conda update -qy conda
 


### PR DESCRIPTION
For now, go ahead and pin the Python minor version. Python 3.7 packages are still missing for some of our dependencies. So it makes more sense to stick to Python 3.6 for now, which is working well for us.