### PR TITLE
Use `jakirkham/centos` as the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:6
+FROM jakirkham/centos
 MAINTAINER John Kirkham <jakirkham@gmail.com>
 
 # Add a timestamp for the build. Also, bust the cache.


### PR DESCRIPTION
Make use of our mirror of the CentOS 6 image. This way we can be sure we can always pull it even if Docker Hub removes their copy in the future.